### PR TITLE
removing hardcoded namespace name from secret.yaml

### DIFF
--- a/charts/traffic-collector-chart/Chart.yaml
+++ b/charts/traffic-collector-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/traffic-collector-chart/templates/secret.yaml
+++ b/charts/traffic-collector-chart/templates/secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.secret.name }}
-  namespace: obs-client
 data:
   COLLECTOR_ID: {{ .Values.secret.collectorId | b64enc | quote }}
   CLIENT_ID: {{ .Values.secret.clientId | b64enc | quote }}


### PR DESCRIPTION
1. Remove the "obs-client" hardcoded ns name -  https://github.com/getastra/obs-deployments/blob/1b385ec9ca6c965afbeaa3a416307bab791e98d5/charts/traffic-collector-chart/templates/secret.yaml#L5