### PR TITLE
Option to give remote address identifier header

### DIFF
--- a/charts/traffic-collector-chart/Chart.yaml
+++ b/charts/traffic-collector-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/traffic-collector-chart/Chart.yaml
+++ b/charts/traffic-collector-chart/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.109.0.1"
+appVersion: "v0.109.0.2"
 icon: https://my.getastra.com/astra-logo.svg

--- a/charts/traffic-collector-chart/templates/secret.yaml
+++ b/charts/traffic-collector-chart/templates/secret.yaml
@@ -8,3 +8,4 @@ data:
   CLIENT_SECRET: {{ .Values.secret.clientSecret | b64enc | quote }}
   TOKEN_URL: {{ .Values.secret.tokenUrl | b64enc | quote }}
   OTLP_ENDPOINT: {{ .Values.secret.otlpEndpoint | b64enc | quote }}
+  REMOTE_ADDR_IDENTIFIER_HEADER: {{ .Values.secret.remoteAddrIdentifierHeader | b64enc | quote }}

--- a/charts/traffic-collector-chart/values.yaml
+++ b/charts/traffic-collector-chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: docker.io/getastra/traffic-collector
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.109.0.1"
+  tag: "v0.109.0.2"
 
 imagePullSecrets: []
 # - name: "dockerhub-pull"
@@ -25,6 +25,7 @@ secret:
   clientSecret: ""
   tokenUrl: ""
   otlpEndpoint: "collect-http.getastra.com:443"
+  remoteAddrIdentifierHeader: ""
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
Give an option via env where user can set what request header can be used to identify the client_addr. If this is non existent or empty, default behavior will be used