### PR TITLE
exposing probabilistic_sampler_prctg env var

### DIFF
--- a/charts/traffic-collector-chart/Chart.yaml
+++ b/charts/traffic-collector-chart/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.109.0.4"
+appVersion: "v0.109.0.5"
 icon: https://my.getastra.com/astra-logo.svg

--- a/charts/traffic-collector-chart/templates/secret.yaml
+++ b/charts/traffic-collector-chart/templates/secret.yaml
@@ -9,3 +9,4 @@ data:
   TOKEN_URL: {{ .Values.secret.tokenUrl | b64enc | quote }}
   OTLP_ENDPOINT: {{ .Values.secret.otlpEndpoint | b64enc | quote }}
   REMOTE_ADDR_IDENTIFIER_HEADER: {{ .Values.secret.remoteAddrIdentifierHeader | b64enc | quote }}
+  PROBABILISTIC_SAMPLER_PERCENTAGE: {{ .Values.secret.probabilisticSamplerPercentage | b64enc | quote }}

--- a/charts/traffic-collector-chart/values.yaml
+++ b/charts/traffic-collector-chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: docker.io/getastra/traffic-collector
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.109.0.4"
+  tag: "v0.109.0.5"
 
 imagePullSecrets: []
 # - name: "dockerhub-pull"
@@ -26,6 +26,7 @@ secret:
   tokenUrl: ""
   otlpEndpoint: "collect-http.getastra.com:443"
   remoteAddrIdentifierHeader: ""
+  probabilisticSamplerPercentage: "100"
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
1. Adding probabilistic_sampler. Default value = 100 which samples all incoming requests.
   -  To set a different value, set: probabilisticSamplerPercentage: 50 under secrets in values.yaml