### PR TITLE
feat: added 4318 port for otlp/http traces

### DIFF
--- a/charts/traffic-collector-chart/templates/service.yaml
+++ b/charts/traffic-collector-chart/templates/service.yaml
@@ -14,6 +14,10 @@ spec:
     - port: 8888
       targetPort: metrics-port
       protocol: TCP
+      name: metric
+    - port: {{ .Values.httpService.port }}
+      targetPort: http-service-port
+      protocol: TCP
       name: http
   selector:
     {{- include "traffic-collector-chart.selectorLabels" . | nindent 4 }}

--- a/charts/traffic-collector-chart/templates/statefulset.yaml
+++ b/charts/traffic-collector-chart/templates/statefulset.yaml
@@ -54,6 +54,9 @@ spec:
             - name: service-port
               containerPort: 4317
               protocol: TCP
+            - name: http-service-port
+              containerPort: 4318
+              protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/charts/traffic-collector-chart/values.yaml
+++ b/charts/traffic-collector-chart/values.yaml
@@ -45,8 +45,10 @@ securityContext:
   allowPrivilegeEscalation: false
   
 service:
-  type: ClusterIP
   port: 4317
+
+httpService:
+  port: 4318
 
 resources: {}
   # If you do want to specify resources, uncomment the following


### PR DESCRIPTION
## Added
- Support for 4318 port to accept otlp/http traces

## Removed
- `service.type` removed from values.yaml file, as we are not using it anywhere